### PR TITLE
Replace license in User's Guide

### DIFF
--- a/doc/user_guide/saclib.tex
+++ b/doc/user_guide/saclib.tex
@@ -33,33 +33,23 @@ Hoon Hong \and Jeremy R.\ Johnson \and Werner Krandick \and R\"{u}diger Loos
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \clearpage \vfill
 \begin{center}
-  \saclib\ \copyright\ 1993 by Kurt G\"{o}del Institute
+  \saclib\ \copyright\ 1993, 2008, RISC-Linz (contact wcbrown@usna.edu)
 \end{center}
 
 \bigskip
 
-The \saclib\ system source code and User's Guide are made available free
-of charge by the Kurt Goedel Institute on behalf of the \saclib\ Group.
+Permission to use, copy, modify, and/or distribute this software, including
+source files, README files, etc., for any purpose with or without fee is
+hereby granted, provided that the above copyright notice and this permission
+notice appear in all copies.
 
-Persons or institutions receiving it are pledged not to distribute it to
-others.  Instead, individuals wishing to acquire the system should obtain it
-by ftp directly from the Kurt Goedel Institute, informing the Institute of
-the acquisition.  Thereby the \saclib\ Group will know who has the system and
-be able to inform all users of any corrections or newer versions.
-
-Users are kindly asked to cite their use of the system in any resulting
-publications or in any application packages built upon \saclib.
-
-Neither \saclib\ nor any part thereof may be incorporated in any commercial
-software product without the consent of the authors.  Users developing
-non-commercial application packages are kindly asked to inform us.
-
-Requests or proposals for changes or additions to the system will
-be welcomed and given consideration.
-
-\saclib\ is offered without warranty of any kind, either expressed or implied.
-However reports of bugs or problems are encouraged.
-
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 \vfill
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Patch from the [Debian package](https://salsa.debian.org/science-team/saclib/-/blob/master/debian/patches/users-guide-license.patch) replacing the original non-free license with the current ISC one to avoid confusion.