### PR TITLE
Add portability CI

### DIFF
--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -1,0 +1,113 @@
+name: Run Sage CI for Linux and macOS
+
+## This GitHub Actions workflow provides:
+##
+##  - portability testing, by building and testing this project on many platforms
+##    (Linux variants, macOS)
+##
+##  - continuous integration, by building and testing other software
+##    that depends on this project.
+##
+## It runs on every push to the GitHub repository.
+##
+## The testing can be monitored in the "Actions" tab of the GitHub repository.
+##
+## After all jobs have finished (or are canceled) and a short delay,
+## tar files of all logs are made available as "build artifacts".
+##
+## This GitHub Actions workflow uses the portability testing framework
+## of SageMath (https://www.sagemath.org/).  For more information, see
+## https://doc.sagemath.org/html/en/developer/portability_testing.html
+
+## The workflow consists of two jobs:
+##
+##  - First, it builds a source distribution of the project
+##    and generates a script "update-pkgs.sh".  It uploads them
+##    as a build artifact named upstream.
+##
+##  - Second, it checks out a copy of the SageMath source tree.
+##    It downloads the upstream artifact and replaces the project's
+##    package in the SageMath distribution by the newly packaged one
+##    from the upstream artifact, by running the script "update-pkgs.sh".
+##    Then it builds a small portion of the Sage distribution.
+##
+## Many copies of the second step are run in parallel for each of the tested
+## systems/configurations.
+
+on:
+  pull_request:
+  push:
+    tags:
+    branches:
+      - main
+  workflow_dispatch:
+    # Allow to run manually
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  # Ubuntu packages to install so that the project can build an sdist
+  DIST_PREREQ:
+  # Name of this project in the Sage distribution
+  SPKG:             saclib
+  REMOVE_PATCHES:   "*"
+
+jobs:
+
+  dist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out ${{ env.SPKG }}
+        uses: actions/checkout@v4
+        with:
+          path: build/pkgs/${{ env.SPKG }}/src
+      - name: Install prerequisites
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install $DIST_PREREQ
+      - name: Run make dist, prepare upstream artifact
+        run: |
+          (cd build/pkgs/${{ env.SPKG }}/src && git archive --format=tar.gz --prefix=${{ env.SPKG }}-git/ HEAD > ${{ env.SPKG }}-git.tar.gz) \
+          && mkdir -p upstream && cp build/pkgs/${{ env.SPKG }}/src/*.tar.gz upstream/${{ env.SPKG }}-git.tar.gz \
+          && echo "sage-package create ${{ env.SPKG }} --version git --tarball ${{ env.SPKG }}-git.tar.gz --type=standard" > upstream/update-pkgs.sh \
+          && if [ -n "${{ env.REMOVE_PATCHES }}" ]; then echo "(cd ../build/pkgs/${{ env.SPKG }}/patches && rm -f ${{ env.REMOVE_PATCHES }}; :)" >> upstream/update-pkgs.sh; fi \
+          && ls -l upstream/
+      - uses: actions/upload-artifact@v4
+        with:
+          path: upstream
+          name: upstream
+
+  linux:
+    uses: passagemath/passagemath/.github/workflows/docker.yml@main
+    with:
+      # Extra system packages to install. See available packages at
+      # https://github.com/sagemath/sage/tree/develop/build/pkgs
+      extra_sage_packages:
+      # Sage distribution packages to build
+      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="saclib" saclib
+      # Standard setting: Test the current HEAD of passagemath:
+      sage_repo: passagemath/passagemath
+      sage_ref: main
+      upstream_artifact: upstream
+      # Docker targets (stages) to tag
+      docker_targets: "with-targets"
+      # We prefix the image name with the SPKG name to avoid the error
+      # 'Package "sage-docker-..." is already associated with another repository.'
+      docker_push_repository: ghcr.io/${{ github.repository }}/saclib_
+    needs: [dist]
+
+  macos:
+    uses: passagemath/passagemath/.github/workflows/macos.yml@main
+    with:
+      # Only warn, do not stop, on soplex test suite failures
+      # https://github.com/scipopt/soplex/issues/35
+      targets:           SAGE_CHECK=no SAGE_CHECK_PACKAGES="saclib" saclib
+      # Naming the stage "1...anything" triggers "sage-local" artifacts to be uploaded
+      stage:             1-with-custom-targets
+      # Standard setting: Test the current HEAD of passagemath:
+      sage_repo: passagemath/passagemath
+      sage_ref: main
+      upstream_artifact: upstream
+    needs: [dist]


### PR DESCRIPTION
Adding a portability CI that builds saclib on many Linux and macOS versions. 

It uses reusable infrastructure from the passagemath project:
- https://github.com/passagemath/passagemath/issues/704

This CI can help with evaluating pull requests such as #1.

Preview: https://github.com/passagemath/saclib/actions/runs/14947259172/job/41992234383